### PR TITLE
Add CLI skeleton with OpenAI integration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -e .
+      - name: Lint
+        run: flake8 codops tests
+      - name: Test
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# codopsai
-AI Chat for product developers
+# codops
+
+Codops is an AI-assisted command line tool for developers. It provides a
+simple interface to OpenAI's ChatGPT for turning natural language into helpful
+commands or documentation snippets.
+
+```bash
+pip install -e .
+# or from PyPI in future
+```
+
+## Usage
+
+```bash
+codops run "say hello"
+```
+
+Use `codops summary --project` to generate project summaries (coming soon).

--- a/codops/__init__.py
+++ b/codops/__init__.py
@@ -1,0 +1,5 @@
+"""Codops package."""
+
+__all__ = ["app"]
+
+from .cli import app

--- a/codops/cli.py
+++ b/codops/cli.py
@@ -1,0 +1,42 @@
+"""CLI for codops."""
+
+from __future__ import annotations
+
+import click
+
+from .openai_client import run_prompt
+
+
+@click.group()
+def app() -> None:
+    """Codops command line interface."""
+
+
+@app.command()
+@click.argument("nl_command", nargs=-1)
+def run(nl_command: tuple[str, ...]) -> None:
+    """Interpret NL_COMMAND via OpenAI and print the result."""
+    prompt = " ".join(nl_command)
+    if not prompt:
+        click.echo("Nothing to run")
+        raise SystemExit(1)
+    try:
+        result = run_prompt(prompt)
+    except Exception as exc:  # pragma: no cover - network errors
+        click.echo(f"Error: {exc}")
+        raise SystemExit(1)
+    click.echo(result)
+
+
+@app.command()
+@click.option("--project", is_flag=True, help="Generate project summary")
+def summary(project: bool) -> None:
+    """Show summary information."""
+    if project:
+        click.echo("Project summary coming soon.")
+    else:
+        click.echo("codops CLI")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/codops/openai_client.py
+++ b/codops/openai_client.py
@@ -1,0 +1,26 @@
+"""OpenAI client wrapper."""
+
+from __future__ import annotations
+
+import os
+
+import openai
+
+_MODEL = "gpt-3.5-turbo"
+
+
+def run_prompt(prompt: str) -> str:
+    """Send prompt to OpenAI and return completion.
+
+    Uses OPENAI_API_KEY env var. Raises RuntimeError if key missing.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not configured")
+
+    client = openai.OpenAI(api_key=api_key)
+    resp = client.chat.completions.create(
+        model=_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.choices[0].message.content.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codops"
+version = "0.1.0"
+description = "AI-assisted CLI for developers"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [ {name = "codops"} ]
+dependencies = [
+    "click",
+    "openai>=1.0",
+]
+
+[project.optional-dependencies]
+web = ["flask"]
+
+[project.scripts]
+codops = "codops.cli:app"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["codops*"]
+
+[tool.pytest.ini_options]
+addopts = "-ra -q"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from click.testing import CliRunner
+
+from codops.cli import app
+
+
+def test_run_empty_command() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["run"])
+    assert result.exit_code != 0
+    assert "Nothing to run" in result.output
+
+
+@mock.patch("codops.cli.run_prompt", return_value="pong")
+def test_run_command(mock_run) -> None:  # type: ignore[no-redef]
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "ping"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "pong"
+
+
+def test_summary_default() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["summary"])
+    assert result.exit_code == 0
+    assert "codops CLI" in result.output
+
+
+def test_summary_project() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["summary", "--project"])
+    assert result.exit_code == 0
+    assert "Project summary" in result.output


### PR DESCRIPTION
## Summary
- add basic codops package with CLI using click
- implement `run` and `summary` commands
- wrap OpenAI call in helper
- set up unit tests and linting
- configure GitHub Actions workflow
- document installation and usage

## Testing
- `python -m flake8 codops tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685993e85d5c83238b2b60d3bd746194