### PR TITLE
Add GitHub and Vercel entrypoints

### DIFF
--- a/.github/workflows/run-codops.yml
+++ b/.github/workflows/run-codops.yml
@@ -1,0 +1,22 @@
+name: Run codops
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt to send to codops'
+        required: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -e .
+      - name: Execute codops
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: codops run "${{ github.event.inputs.prompt }}"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ pip install -e .
 # or from PyPI in future
 ```
 
+## Run directly from GitHub
+
+You can install the latest version straight from a repository without
+cloning:
+
+```bash
+pip install git+https://github.com/<your-user>/codopsai.git
+```
+
+Replace `<your-user>` with the GitHub owner of this project.
+
 ## Usage
 
 ```bash
@@ -16,3 +27,15 @@ codops run "say hello"
 ```
 
 Use `codops summary --project` to generate project summaries (coming soon).
+
+## Deploy to Vercel
+
+Deploy the API as a serverless function on Vercel:
+
+```bash
+vercel --prod
+```
+
+Make sure to set the `OPENAI_API_KEY` environment variable in your Vercel
+project settings. The API accepts a `prompt` parameter via query string or JSON
+body and returns the completion.

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+
+from codops.openai_client import run_prompt
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["GET", "POST"])
+def handle() -> tuple[str, int] | tuple[dict[str, str], int]:
+    """Vercel entrypoint for codops."""
+    prompt = request.args.get("prompt")
+    if request.is_json:
+        prompt = request.get_json(silent=True).get("prompt") or prompt
+    if not prompt:
+        return {"error": "Missing prompt"}, 400
+    try:
+        result = run_prompt(prompt)
+    except Exception as exc:  # pragma: no cover - network errors
+        return {"error": str(exc)}, 500
+    return jsonify(response=result), 200
+
+
+# Export app for Vercel
+handler = app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+codops[web] @ file://.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "api/*.py": { "runtime": "python3.11" }
+  }
+}


### PR DESCRIPTION
## Summary
- allow installing package directly from GitHub in README
- document Vercel deployment instructions
- add API handler for Vercel
- provide requirements.txt and vercel.json
- add GitHub workflow to run codops on demand

## Testing
- `flake8 codops tests api`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685997d68fc88323bbcb307f83abcfea